### PR TITLE
Focus project on arbitrage trading for new users

### DIFF
--- a/hummingbot/client/command/import_command.py
+++ b/hummingbot/client/command/import_command.py
@@ -53,11 +53,34 @@ class ImportCommand:
             self.app.change_prompt(prompt=">>> ")
             raise
         self.strategy_file_name = file_name
-        self.strategy_name = (
-            config_map.strategy
-            if not isinstance(config_map, dict)
-            else config_map.get("strategy").value  # legacy
-        )
+        if isinstance(config_map, ClientConfigAdapter):
+            if hasattr(config_map.hb_config, 'strategy'):  # Legacy or script with Pydantic
+                self.strategy_name = config_map.strategy
+            elif hasattr(config_map.hb_config, 'controller_name'):  # V2 Controller
+                self.strategy_name = config_map.controller_name
+            else:
+                # Handle error or raise exception if neither is found
+                self.notify(f"Cannot determine strategy or controller name from {self.strategy_file_name}")
+                # self._in_start_check = False # Ensure start is aborted if this was part of start
+                # The above line is commented out as _in_start_check is not a standard attribute of ImportCommand or HummingbotApplication
+                self.strategy_file_name = None
+                # Reset prompt settings
+                self.placeholder_mode = False
+                self.app.hide_input = False
+                self.app.change_prompt(prompt=">>> ")
+                return  # Or raise an error
+        elif isinstance(config_map, dict):  # Legacy dict-based config_map
+            self.strategy_name = config_map.get("strategy").value
+        else:
+            # Handle unexpected config_map type
+            self.notify(f"Unknown configuration map type for {self.strategy_file_name}")
+            self.strategy_file_name = None
+            # Reset prompt settings
+            self.placeholder_mode = False
+            self.app.hide_input = False
+            self.app.change_prompt(prompt=">>> ")
+            return
+
         self.strategy_config_map = config_map
         self.notify(f"Configuration from {self.strategy_file_name} file is imported.")
         self.placeholder_mode = False

--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -26,6 +26,9 @@ from hummingbot.exceptions import InvalidScriptModule, OracleRateUnavailable
 from hummingbot.strategy.directional_strategy_base import DirectionalStrategyBase
 from hummingbot.strategy.script_strategy_base import ScriptStrategyBase
 from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
+from hummingbot.strategy_v2.controllers.controller_base import ControllerBase
+from hummingbot.data_feed.market_data_provider import MarketDataProvider
+
 
 if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication  # noqa: F401
@@ -267,13 +270,63 @@ class StartCommand(GatewayChainApiManager):
             self.logger().error(str(e), exc_info=True)
 
     def _initialize_strategy(self, strategy_name: str):
-        if self.is_current_strategy_script_strategy():
+        if self.is_current_strategy_script_strategy(): # Checks for .py file in scripts folder
             self.start_script_strategy()
-        else:
-            start_strategy: Callable = get_strategy_starter_file(strategy_name)
-            if strategy_name in settings.STRATEGIES:
-                start_strategy(self)
+        elif hasattr(self.strategy_config_map.hb_config, 'controller_name'): # Check if it's a V2 Controller
+            # Logic to initialize V2 Controller
+            controller_config = self.strategy_config_map.hb_config # This is the actual Pydantic model instance
+
+            known_controller_subfolders = ["generic", "market_making", "directional_trading"]
+            controller_module = None
+            actual_controller_name_from_config = self.strategy_config_map.controller_name # e.g. "arbitrage_controller"
+
+            for subfolder in known_controller_subfolders:
+                try:
+                    module_path_str = f"{settings.CONTROLLERS_MODULE}.{subfolder}.{actual_controller_name_from_config}"
+                    controller_module = importlib.import_module(module_path_str)
+                    break
+                except ImportError:
+                    continue
+
+            if not controller_module:
+                self.notify(f"Could not find controller module for {actual_controller_name_from_config}")
+                raise NotImplementedError
+
+            controller_class = next((member for member_name, member in inspect.getmembers(controller_module)
+                                     if inspect.isclass(member) and
+                                     issubclass(member, ControllerBase) and
+                                     member is not ControllerBase), None)
+
+            if not controller_class:
+                self.notify(f"Could not find controller class in module for {actual_controller_name_from_config}")
+                raise NotImplementedError
+
+            markets_to_initialize = {}
+            if hasattr(controller_config, 'update_markets') and callable(getattr(controller_config, 'update_markets')):
+                 markets_to_initialize = controller_config.update_markets({})
+
+            market_names_tuples = []
+            for conn_name, trading_pairs_set in markets_to_initialize.items():
+                market_names_tuples.append((conn_name, list(trading_pairs_set)))
+
+            self._initialize_markets(market_names_tuples)
+
+            if not hasattr(self, 'market_data_provider') or not isinstance(self.market_data_provider, MarketDataProvider):
+                 self.market_data_provider = MarketDataProvider(list(self.markets.values()), self.client_config_map)
+                 self.market_data_provider.start()
+
+            self.strategy = controller_class(
+                config=controller_config,
+                market_data_provider=self.market_data_provider,
+                strategy_name=actual_controller_name_from_config
+            )
+
+        else: # Legacy strategies
+            start_strategy_fn: Callable = get_strategy_starter_file(strategy_name)
+            if strategy_name in settings.STRATEGIES: # settings.STRATEGIES is for legacy strategies
+                start_strategy_fn(self) # This typically sets self.strategy
             else:
+                self.notify(f"Unknown strategy type: {strategy_name}. Start aborted.")
                 raise NotImplementedError
 
     async def confirm_oracle_conversion_rate(self,  # type: HummingbotApplication

--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -25,18 +25,29 @@ from hummingbot.client.config.config_data_types import BaseClientModel, ClientCo
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.fee_overrides_config_map import fee_overrides_config_map, init_fee_overrides_config
 from hummingbot.client.config.gateway_ssl_config_map import SSLConfigMap
+from hummingbot.client import settings
 from hummingbot.client.settings import (
     CLIENT_CONFIG_PATH,
     CONF_DIR_PATH,
+    CONTROLLERS_MODULE,
     CONF_POSTFIX,
     CONF_PREFIX,
     CONNECTORS_CONF_DIR_PATH,
     GATEWAY_SSL_CONF_FILE,
     STRATEGIES_CONF_DIR_PATH,
+    CONTROLLERS_CONF_DIR_PATH,
     TEMPLATE_PATH,
     TRADE_FEES_CONFIG_PATH,
     AllConnectorSettings,
 )
+from hummingbot.strategy_v2.controllers.controller_base import ControllerConfigBase
+from hummingbot.strategy_v2.controllers.directional_trading_controller_base import (
+    DirectionalTradingControllerConfigBase,
+)
+from hummingbot.strategy_v2.controllers.market_making_controller_base import MarketMakingControllerConfigBase
+
+CONTROLLERS_CONF_DIR_PATH = CONF_DIR_PATH / "controllers"
+import importlib
 
 
 class ConfigValidationError(Exception):
@@ -628,17 +639,59 @@ def get_strategy_pydantic_config_cls(strategy_name: str):
 
 
 async def load_strategy_config_map_from_file(yml_path: Path) -> Union[ClientConfigAdapter, Dict[str, ConfigVar]]:
-    strategy_name = strategy_name_from_file(yml_path)
-    config_cls = get_strategy_pydantic_config_cls(strategy_name)
-    if config_cls is None:  # legacy
-        config_map = get_strategy_config_map(strategy_name)
-        template_path = get_strategy_template_path(strategy_name)
-        await load_yml_into_cm_legacy(str(yml_path), str(template_path), config_map)
-    else:
-        config_data = read_yml_file(yml_path)
-        hb_config = config_cls(**config_data)
+    config_data = read_yml_file(yml_path)
+    controller_name = config_data.get("controller_name")
+
+    if controller_name:
+        known_controller_subfolders = ["generic", "market_making", "directional_trading"]
+        controller_module = None
+        for subfolder in known_controller_subfolders:
+            try:
+                module_path_str = f"{CONTROLLERS_MODULE}.{subfolder}.{controller_name}"
+                controller_module = importlib.import_module(module_path_str)
+                break  # Found it
+            except ImportError:
+                continue
+
+        if not controller_module:
+            raise FileNotFoundError(
+                f"Controller module for '{controller_name}' not found in known subfolders: {known_controller_subfolders}."
+            )
+
+        config_class = next(
+            (
+                member
+                for member_name, member in inspect.getmembers(controller_module)
+                if inspect.isclass(member)
+                and issubclass(member, ControllerConfigBase)
+                and member not in [
+                    ControllerConfigBase,
+                    MarketMakingControllerConfigBase,
+                    DirectionalTradingControllerConfigBase,
+                ]
+            ),
+            None,
+        )
+
+        if not config_class:
+            raise TypeError(f"No suitable config class found in {controller_module}")
+
+        hb_config = config_class(**config_data)
         config_map = ClientConfigAdapter(hb_config)
-    return config_map
+        return config_map
+    else:  # Existing logic for strategies
+        strategy_name = strategy_name_from_file(yml_path)  # This will use the already read config_data
+        if not strategy_name: # If strategy field is also not found, then it's an invalid file.
+            raise ValueError(f"The configuration file {yml_path} is not a valid strategy or controller file.")
+        config_cls = get_strategy_pydantic_config_cls(strategy_name)
+        if config_cls is None:  # legacy
+            config_map = get_strategy_config_map(strategy_name)
+            template_path = get_strategy_template_path(strategy_name)
+            await load_yml_into_cm_legacy(str(yml_path), str(template_path), config_map)
+        else:
+            hb_config = config_cls(**config_data)
+            config_map = ClientConfigAdapter(hb_config)
+        return config_map
 
 
 def load_connector_config_map_from_file(yml_path: Path) -> ClientConfigAdapter:
@@ -652,11 +705,14 @@ def load_connector_config_map_from_file(yml_path: Path) -> ClientConfigAdapter:
 
 def load_client_config_map_from_file() -> ClientConfigAdapter:
     yml_path = CLIENT_CONFIG_PATH
+    is_fresh_install = not yml_path.exists()
     if yml_path.exists():
         config_data = read_yml_file(yml_path)
     else:
         config_data = {}
     client_config = ClientConfigMap(**config_data)
+    if is_fresh_install and client_config.previous_strategy is None:
+        client_config.previous_strategy = "arbitrage_controller_default.yml"
     config_map = ClientConfigAdapter(client_config)
     save_to_yml(yml_path, config_map)
     return config_map
@@ -857,8 +913,20 @@ async def create_yml_files_legacy():
     """
     Copy `hummingbot_logs.yml` and `conf_global.yml` templates to the `conf` directory on start up
     """
+    # Ensure the controllers directory exists
+    CONTROLLERS_CONF_DIR_PATH.mkdir(parents=True, exist_ok=True)
+
+    # Copy arbitrage_controller template
+    arbitrage_controller_template_fname = "conf_arbitrage_controller_TEMPLATE.yml"
+    arbitrage_controller_template_path = TEMPLATE_PATH / arbitrage_controller_template_fname
+    arbitrage_controller_dest_fname = "arbitrage_controller_default.yml"
+    arbitrage_controller_dest_path = CONTROLLERS_CONF_DIR_PATH / arbitrage_controller_dest_fname
+
+    if not arbitrage_controller_dest_path.is_file():
+        shutil.copy(str(arbitrage_controller_template_path), str(arbitrage_controller_dest_path))
+
     for fname in listdir(TEMPLATE_PATH):
-        if "_TEMPLATE" in fname and CONF_POSTFIX not in fname:
+        if "_TEMPLATE" in fname and CONF_POSTFIX not in fname and fname != arbitrage_controller_template_fname:
             stripped_fname = fname.replace("_TEMPLATE", "")
             template_path = str(TEMPLATE_PATH / fname)
             conf_path = join(CONF_DIR_PATH, stripped_fname)

--- a/hummingbot/templates/conf_arbitrage_controller_TEMPLATE.yml
+++ b/hummingbot/templates/conf_arbitrage_controller_TEMPLATE.yml
@@ -1,0 +1,49 @@
+# Arbitrage Controller Configuration Template
+# This file defines the configuration for the ArbitrageController.
+# For more information, please refer to the documentation.
+
+# Name of the controller
+controller_name: arbitrage_controller
+
+# Configuration for candles feed, used for market data
+# Example:
+# candles_config:
+#   - connector: binance
+#     trading_pair: BTC-USDT
+#     interval: 1m
+#     max_records: 100
+candles_config: []
+
+# First exchange and trading pair for arbitrage
+exchange_pair_1:
+  connector_name: binance  # Example: Name of the first exchange (e.g., binance, kucoin)
+  trading_pair: BTC-USDT   # Example: Trading pair on the first exchange (e.g., BTC-USDT, ETH-BTC)
+
+# Second exchange and trading pair for arbitrage
+exchange_pair_2:
+  connector_name: kucoin   # Example: Name of the second exchange
+  trading_pair: BTC-USDT   # Example: Trading pair on the second exchange
+
+# Minimum profitability required for an arbitrage opportunity to be executed
+# This is expressed as a decimal (e.g., 0.01 represents 1%)
+min_profitability: 0.01
+
+# Total amount in quote currency to be used for each arbitrage trade
+# Example: If quote_conversion_asset is USDT, this is the amount in USDT
+total_amount_quote: 1000
+
+# Delay in seconds between the creation of new executors
+# This helps to avoid placing too many orders too quickly
+delay_between_executors: 10
+
+# Maximum imbalance allowed between buy and sell executors
+# This helps to manage risk by preventing too many one-sided trades
+max_executors_imbalance: 1
+
+# Connector to be used for fetching rate conversions
+# This is important if the quote assets of the two pairs are different or if gas is involved
+rate_connector: binance # Example: binance
+
+# The asset to which all quote currencies will be converted for profitability calculation
+# Example: USDT, BUSD, USDC
+quote_conversion_asset: USDT


### PR DESCRIPTION
This change makes the ArbitrageController the default strategy for new
Hummingbot instances.

Key changes include:
- Added a template for ArbitrageController configuration (`conf_arbitrage_controller_TEMPLATE.yml`).
- Modified `create_yml_files_legacy` to copy this template to
  `conf/controllers/arbitrage_controller_default.yml` on startup if it doesn't exist.
- Updated `load_client_config_map_from_file` to set
  `previous_strategy` to "arbitrage_controller_default.yml" in the global
  config (`conf_global.yml`) for first-time setups.
- Enhanced strategy loading mechanisms in `ImportCommand` and `StartCommand`
  to correctly detect, load, and initialize V2 Controller configurations
  (like ArbitrageController) from YAML files specified by `previous_strategy`
  or the import command. This involves identifying controllers by the
  `controller_name` key in their YAML configs and dynamically loading the
  appropriate controller class and its Pydantic config model.